### PR TITLE
Misc improvements: granularity converter, trade balance, study manager, aggregations, config system

### DIFF
--- a/mesqual/databases/pickle_db.py
+++ b/mesqual/databases/pickle_db.py
@@ -2,11 +2,28 @@ from typing import Optional, List
 import os
 import glob
 from pathlib import Path
+import hashlib
 
 import pandas as pd
 
 from mesqual.typevars import DatasetType, FlagType, DatasetConfigType
 from mesqual.databases.database import Database
+
+
+def _stable_hash(value: str | int) -> int:
+    return int(hashlib.md5(str(value).encode()).hexdigest(), 16)
+
+
+def _normalize_for_hash(value):
+    """Normalize values for deterministic hashing. Sorts lists and sets so
+    iteration order doesn't affect the hash."""
+    if isinstance(value, (set, frozenset)):
+        return sorted(value)
+    if isinstance(value, list):
+        return sorted(value)
+    if isinstance(value, dict):
+        return sorted(value.items())
+    return value
 
 
 class PickleDatabase(Database):
@@ -125,16 +142,15 @@ class PickleDatabase(Database):
             return ""
 
         attrs = {
-            name: getattr(config, name)
-            for name in dir(config)
-            if not name.startswith('_') and not callable(getattr(config, name))
+            k: _normalize_for_hash(v) for k, v in vars(config).items()
+            if not k.startswith('_')
         }
 
         sorted_items = sorted(attrs.items())
 
         # Convert to string representation for hashing
         config_str = str(sorted_items)
-        return str(hash(config_str))
+        return str(_stable_hash(config_str))
 
     def _get_kwargs_hash(self, kwargs: dict) -> str:
         """Generate hash for keyword arguments dictionary.
@@ -154,7 +170,7 @@ class PickleDatabase(Database):
         }
 
         sorted_items = sorted(str_dict.items())
-        return str(hash(str(sorted_items)))
+        return str(_stable_hash(str(sorted_items)))
 
     def _get_file_path(self, dataset: DatasetType, flag: FlagType, config: DatasetConfigType = None, **kwargs) -> str:
         """Generate file path for the given parameters.

--- a/mesqual/datasets/dataset_collection.py
+++ b/mesqual/datasets/dataset_collection.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 import pandas as pd
 
 from mesqual.datasets.dataset import Dataset
+from mesqual.enums import ItemTypeEnum
 from mesqual.flag.flag_index import FlagIndex
 from mesqual.utils.pandas_utils.is_numeric import pd_is_numeric
 from mesqual.utils.logging import get_logger
@@ -589,16 +590,42 @@ class DatasetSumCollection(
     Generic[DatasetType, DatasetConfigType, FlagType, FlagIndexType],
     DatasetCollection[DatasetType, DatasetConfigType, FlagType, FlagIndexType]
 ):
-    def _fetch(self, flag: FlagType, effective_config: DatasetConfigType, **kwargs) -> pd.Series | pd.DataFrame:
-        data: list[pd.Series | pd.DataFrame] = []
-        for ds in self.datasets:
-            if ds.flag_is_accepted(flag):
-                data.append(ds.fetch(flag, effective_config, **kwargs))
-        if not data:
-            raise KeyError(f"Flag '{flag}' not recognized by any of the linked Datasets in {type(self)} {self.name}.")
-        
-        if all(pd_is_numeric(d) for d in data):
-            import numpy as np
-            return np.sum(data)
+    """
+    Sums Timeseries flags of child-datasets; Applies DatasetMergeCollection Logic for model flags.
+    """
 
-        raise NotImplementedError
+    @property
+    def _merge_collection(self) -> DatasetMergeCollection:
+        return DatasetMergeCollection(
+            self.datasets,
+            name=self.name,
+            flag_index=self.flag_index,
+            attributes=self.attributes,
+            database=self.database,
+            config=self.instance_config,
+            keep_first=True
+        )
+
+    def _fetch(self, flag: FlagType, effective_config: DatasetConfigType, **kwargs) -> pd.Series | pd.DataFrame:
+
+        # In case of "model flag", return the merged model (don't sum)
+        item_type = self.flag_index.get_item_type(flag)
+        if item_type == ItemTypeEnum.Model:
+            return self._merge_collection.fetch(flag, effective_config, **kwargs)
+
+        # In case of "time-series flag", return the
+        elif item_type == ItemTypeEnum.TimeSeries:
+            data: list[pd.Series | pd.DataFrame] = []
+            for ds in self.datasets:
+                if ds.flag_is_accepted(flag):
+                    data.append(ds.fetch(flag, effective_config, **kwargs))
+            if not data:
+                raise KeyError(f"Flag '{flag}' not recognized by any of the linked Datasets in {type(self)} {self.name}.")
+
+            if all(pd_is_numeric(d) for d in data):
+                import numpy as np
+                return np.sum(data)
+
+        raise NotImplementedError(
+            f'No Handling for item_type {item_type} of flag {flag} implemented in {self.__class__.__name__}'
+        )

--- a/mesqual/datasets/dataset_collection.py
+++ b/mesqual/datasets/dataset_collection.py
@@ -623,8 +623,8 @@ class DatasetSumCollection(
                 raise KeyError(f"Flag '{flag}' not recognized by any of the linked Datasets in {type(self)} {self.name}.")
 
             if all(pd_is_numeric(d) for d in data):
-                import numpy as np
-                return np.sum(data)
+                from functools import reduce
+                return reduce(lambda a, b: a.add(b, fill_value=0), data)
 
         raise NotImplementedError(
             f'No Handling for item_type {item_type} of flag {flag} implemented in {self.__class__.__name__}'

--- a/mesqual/datasets/dataset_config.py
+++ b/mesqual/datasets/dataset_config.py
@@ -172,9 +172,9 @@ class DatasetConfig:
 
         merged_config = self.__class__()
 
-        for attr_name in dir(self):
-            if not attr_name.startswith('_'):  # Skip private attributes
-                setattr(merged_config, attr_name, getattr(self, attr_name))
+        for k, v in vars(self).items():
+            if not k.startswith('_'):
+                setattr(merged_config, k, v)
 
         if isinstance(other, dict):
             for key, value in other.items():
@@ -182,21 +182,15 @@ class DatasetConfig:
                     setattr(merged_config, key, value)
             return merged_config
 
-        for attr_name in dir(other):
-            if not attr_name.startswith('_'):
-                other_value = getattr(other, attr_name)
-                if other_value is not None:
-                    setattr(merged_config, attr_name, other_value)
+        for k, v in vars(other).items():
+            if not k.startswith('_') and v is not None:
+                setattr(merged_config, k, v)
 
         return merged_config
 
     def __repr__(self) -> str:
         """Return a string representation showing all config attributes."""
-        attrs = {
-            name: getattr(self, name)
-            for name in dir(self)
-            if not name.startswith('_') and not callable(getattr(self, name))
-        }
+        attrs = {k: v for k, v in vars(self).items() if not k.startswith('_')}
         return f"{self.__class__.__name__}({attrs})"
 
 

--- a/mesqual/datasets/dataset_config.py
+++ b/mesqual/datasets/dataset_config.py
@@ -368,10 +368,13 @@ class DatasetConfigManager:
         """
         config_type = dataset_class.get_config_type()
         base_config = config_type()
-        class_config = cls._class_configs.get(dataset_class)
 
-        if class_config:
-            base_config = base_config.merge(class_config)
+        # Walk MRO from most generic to most specific, merging class configs
+        for klass in reversed(dataset_class.__mro__):
+            class_config = cls._class_configs.get(klass)
+            if class_config:
+                base_config = base_config.merge(class_config)
+
         if instance_config:
             base_config = base_config.merge(instance_config)
 

--- a/mesqual/energy_data_handling/area_accounting/border_variable_capacity_calculator.py
+++ b/mesqual/energy_data_handling/area_accounting/border_variable_capacity_calculator.py
@@ -51,7 +51,8 @@ class BorderCapacityCalculator(AreaBorderVariableCalculatorBase):
         Direction logic:
         - 'up': Capacities for flows from area_from to area_to
         - 'down': Capacities for flows from area_to to area_from
-        
+        - 'total': Sum capacities in both directions
+
         For each border, the method:
         1. Identifies lines in 'up' and 'down' topological directions
         2. Selects appropriate capacity data based on requested direction
@@ -72,7 +73,7 @@ class BorderCapacityCalculator(AreaBorderVariableCalculatorBase):
             total transmission capacity in MW for each border and timestamp.
             
         Raises:
-            ValueError: If direction is not 'up' or 'down'
+            ValueError: If direction is not 'up', 'down', or 'total'
             
         Example:
             
@@ -84,6 +85,9 @@ class BorderCapacityCalculator(AreaBorderVariableCalculatorBase):
             >>> 
             >>> print(f"DE→FR capacity: {up_caps.loc['2024-01-01 12:00', 'DE-FR']:.0f} MW")
         """
+        if direction == 'total':
+            return self.calculate(line_capacity_data, 'up') + self.calculate(line_capacity_data, 'down')
+
         self._validate_time_series_data(line_capacity_data.capacities_up, "capacities_up")
         self._validate_time_series_data(line_capacity_data.capacities_down, "capacities_down")
         

--- a/mesqual/energy_data_handling/granularity_converter.py
+++ b/mesqual/energy_data_handling/granularity_converter.py
@@ -3,316 +3,147 @@ from enum import Enum
 import pandas as pd
 
 from mesqual.enums import QuantityTypeEnum
-from mesqual.energy_data_handling.granularity_analyzer import TimeSeriesGranularityAnalyzer
 
 
 class GranularityConversionError(Exception):
-    """Exception raised when granularity conversion operations fail.
-    
-    This exception is raised when conversion between different time granularities
-    cannot be performed due to incompatible data formats, unsupported granularities,
-    or other conversion-specific errors.
-    """
+    """Exception raised when granularity conversion operations fail."""
     pass
 
 
 class SamplingMethodEnum(Enum):
-    """Enumeration of sampling methods for granularity conversion.
-    
-    Attributes:
-        UPSAMPLING: Converting from coarser to finer granularity (e.g., hourly to 15-min)
-        DOWNSAMPLING: Converting from finer to coarser granularity (e.g., 15-min to hourly)
-        KEEP: No conversion needed - source and target granularities are the same
-    """
     UPSAMPLING = 'upsampling'
     DOWNSAMPLING = 'downsampling'
     KEEP = 'keep'
 
 
 class TimeSeriesGranularityConverter:
-    """Converts time series between different granularities while respecting the nature of the quantity.
+    """Converts time series between different granularities while respecting quantity type.
 
-    This class handles the conversion of time series data between different granularities
-    (e.g., hourly to 15-min or vice versa) while properly accounting for the physical
-    nature of the quantity being converted:
+    Handles both upsampling (coarser → finer) and downsampling (finer → coarser):
 
-    - Intensive quantities (e.g., prices, power levels) are replicated when increasing
-      granularity and averaged when decreasing granularity.
+    - Intensive quantities (prices, power): ffill when upsampling, mean when downsampling
+    - Extensive quantities (volumes, welfare): ffill/÷spread when upsampling, sum when downsampling
 
-    - Extensive quantities (e.g., volumes, welfare) are split when increasing
-      granularity and summed when decreasing granularity.
+    Works on both Series and DataFrames, including DataFrames with mixed-granularity
+    columns (e.g., some columns hourly, others 15-min within the same DataFrame).
+    The conversion is applied per-column — columns already at the target frequency
+    pass through unchanged.
 
-    Features:
-        - Automatic granularity detection using TimeGranularityAnalyzer
-        - Per-day processing to handle missing periods properly and prevent incorrect autofilling of missing days
-        - Support for both intensive and extensive quantities
-        - Timezone-aware processing including daylight saving transitions
+    Uses pandas resample directly, avoiding explicit granularity analysis of the source data.
+    Forward-fill is bounded per calendar day to prevent bleeding across data gaps.
     """
-    def __init__(self):
-        """Initialize the granularity converter with analyzer instances.
-        
-        Creates both strict and non-strict granularity analyzers for different
-        validation requirements during conversion operations.
-        """
-        self._strict_gran_analyzer = TimeSeriesGranularityAnalyzer(strict_mode=True)
-        self._non_strict_gran_analyzer = TimeSeriesGranularityAnalyzer(strict_mode=False)
 
-    def _validate_series_format(self, series: pd.Series) -> None:
-        """Validate that the input series has the required DatetimeIndex format.
-        
-        Args:
-            series: Time series to validate
-            
-        Raises:
-            TypeError: If series index is not a DatetimeIndex
-        """
-        if not isinstance(series.index, pd.DatetimeIndex):
-            raise TypeError(f"Series index must be DatetimeIndex, got {type(series.index)}")
-
-    def upsample_through_fillna(
-            self,
-            data: pd.DataFrame | pd.Series,
-            quantity_type: QuantityTypeEnum
+    def convert(
+        self,
+        data: pd.DataFrame | pd.Series,
+        target_freq: str | pd.Timedelta,
+        quantity_type: QuantityTypeEnum,
     ) -> pd.DataFrame | pd.Series:
-        """Upsample data using forward-fill strategy with quantity-type-aware scaling.
-        
-        This method handles upsampling of sparse data where some values are missing.
-        It uses forward-fill to propagate values and applies appropriate scaling
-        based on the quantity type:
-        
-        - For INTENSIVE quantities: Values are replicated without scaling
-        - For EXTENSIVE quantities: Values are divided by the number of periods
-          they are spread across within each hour-segment group
-        
-        The method processes data per day and hour to handle missing periods properly
-        and prevent incorrect auto-filling across day boundaries.
-        
+        """Convert time series data to a target frequency.
+
         Args:
-            data: Time series data to upsample (Series or DataFrame)
-            quantity_type: Type of quantity being converted (INTENSIVE or EXTENSIVE)
-            
+            data: Input time series with DatetimeIndex.
+            target_freq: Target frequency as a Timedelta or timedelta-compatible string
+                         (e.g., "15min", "1h", pd.Timedelta(hours=1)).
+            quantity_type: INTENSIVE (prices, power) or EXTENSIVE (volumes, welfare).
+
         Returns:
-            Upsampled data with same type as input
-            
-        Example:
-            
-            >>> # For extensive quantities (energy), values are divided
-            >>> series = pd.Series([100, np.nan, np.nan, np.nan, 200, np.nan, np.nan, np.nan],
-            ...                   index=pd.date_range('2024-01-01', freq='15min', periods=5))
-            >>> converter.upsample_through_fillna(series, QuantityTypeEnum.EXTENSIVE)
-                # Results in [25, 25, 25, 25, 50, 50, 50, 50]
+            Converted data, same type as input (Series or DataFrame).
         """
-        if isinstance(data, pd.Series):
-            return self._upsample_series(data, quantity_type)
+        is_series = isinstance(data, pd.Series)
+        df = data.to_frame() if is_series else data
 
-        tmp = data.copy().sort_index()
-        idx = tmp.index.tz_convert('UTC') if tmp.index.tz is not None else tmp.index
+        if not isinstance(df.index, pd.DatetimeIndex):
+            raise TypeError(f"Index must be DatetimeIndex, got {type(df.index)}")
 
-        if quantity_type == QuantityTypeEnum.EXTENSIVE:
-            segment_patterns = tmp.notna().cumsum()
+        target_td = target_freq if isinstance(target_freq, pd.Timedelta) else pd.Timedelta(target_freq)
+        index_step = df.index.to_series().diff().median()
 
-            # Group columns by their segment pattern
-            pattern_to_cols = {}
-            for col in tmp.columns:
-                pattern = tuple(segment_patterns[col].values)  # Convert to tuple to make it hashable
-                pattern_to_cols.setdefault(pattern, []).append(col)
-
-            # Process each group of columns with same pattern
-            result_pieces = []
-            for pattern, cols in pattern_to_cols.items():
-                segments = segment_patterns[cols[0]]  # Take segments from first column (all are same)
-                piece = (
-                    tmp[cols]
-                    .groupby([idx.date, idx.hour, segments])
-                    .transform(lambda s: s.ffill() / len(s))
-                )
-                result_pieces.append(piece)
-
-            return pd.concat(result_pieces, axis=1).loc[data.index].rename_axis(data.columns.names, axis=1)
+        if target_td > index_step:
+            result = self._downsample(df, target_td, quantity_type)
+        elif target_td < index_step or df.isna().any().any():
+            result = self._upsample(df, target_td, quantity_type)
         else:
-            return tmp.groupby([idx.date, idx.hour]).ffill().loc[data.index]
+            result = df
 
-    def _upsample_series(self, series: pd.Series, quantity_type: QuantityTypeEnum) -> pd.Series:
-        """Helper method to upsample a Series using DataFrame-based upsampling.
-        
-        Args:
-            series: Time series to upsample
-            quantity_type: Type of quantity being converted
-            
-        Returns:
-            Upsampled series
-        """
-        return self.upsample_through_fillna(
-            series.to_frame(),
-            quantity_type
-        ).iloc[:, 0]
+        if is_series:
+            return result.iloc[:, 0].rename(data.name)
+        return result
 
     def convert_to_target_index(
-            self,
-            series: pd.Series,
-            target_index: pd.DatetimeIndex,
-            quantity_type: QuantityTypeEnum
-    ) -> pd.Series:
-        """Convert a time series to match a specific target DatetimeIndex.
-        
-        This method converts the granularity of a time series to match the granularity
-        of a target index. The target index must have consistent granularity within
-        each day and consistent granularity across all days.
-        
-        Args:
-            series: Source time series to convert
-            target_index: DatetimeIndex defining the target granularity and timestamps
-            quantity_type: Type of quantity (INTENSIVE or EXTENSIVE) for proper scaling
-            
-        Returns:
-            Series converted to match target index granularity and timestamps
-            
-        Raises:
-            ValueError: If target index has multiple granularities within days
-                       or inconsistent granularity across days
-            
-        Example:
-            
-            >>> # Convert hourly to 15-min data
-            >>> hourly_series = pd.Series([100, 150, 200], 
-            ...                          index=pd.date_range('2024-01-01', freq='1H', periods=3))
-            >>> target_idx = pd.date_range('2024-01-01', freq='15min', periods=12)
-            >>> result = converter.convert_to_target_index(hourly_series, target_idx,
-            ...                                          QuantityTypeEnum.INTENSIVE)
-        """
-        self._validate_series_format(series)
-        target_gran_series = self._strict_gran_analyzer.get_granularity_as_series_of_timedeltas(target_index)
-        _grouped = target_gran_series.groupby(target_gran_series.index.date)
-        if _grouped.nunique().max() > 1:
-            raise ValueError(f"Found some dates with multiple granularities within same day. Can't handle that!")
-        if _grouped.first().nunique() > 1:
-            raise ValueError(f"Found multiple granularities. Can't handle that!")
-        target_granularity = pd.Timedelta(target_gran_series.values[0])
-        return series.groupby(series.index.date).apply(
-            lambda x: self._convert_date_to_target_granularity(x, target_granularity, quantity_type)
-        ).droplevel(0).rename_axis(series.index.name).rename(series.name)
-
-    def convert_to_target_granularity(
-            self,
-            series: pd.Series,
-            target_granularity: pd.Timedelta,
-            quantity_type: QuantityTypeEnum
-    ) -> pd.Series:
-        """Convert a time series to a specific target granularity.
-        
-        This method converts the temporal granularity of a time series while properly
-        handling the physical nature of the quantity. The conversion is performed
-        day-by-day to prevent incorrect handling of missing days or daylight saving
-        time transitions.
-        
-        Args:
-            series: Source time series to convert
-            target_granularity: Target granularity as a pandas Timedelta
-                               (e.g., pd.Timedelta(minutes=15) for 15-minute data)
-            quantity_type: Type of quantity for proper scaling:
-                          - INTENSIVE: Values are averaged/replicated (prices, power)
-                          - EXTENSIVE: Values are summed/split (volumes, energy)
-                          
-        Returns:
-            Series with converted granularity, maintaining original naming and metadata
-            
-        Raises:
-            GranularityConversionError: If conversion cannot be performed due to
-                                       unsupported granularities or data issues
-                                       
-        Example:
-            
-            >>> # Convert 15-minute to hourly data (downsampling)
-            >>> quarter_hourly = pd.Series([25, 30, 35, 40], 
-            ...                           index=pd.date_range('2024-01-01', freq='15min', periods=4))
-            >>> hourly = converter.convert_to_target_granularity(
-            ...     quarter_hourly, pd.Timedelta(hours=1), QuantityTypeEnum.EXTENSIVE)
-            >>> print(hourly)  # Result: [130] (25+30+35+40)
-        """
-        self._validate_series_format(series)
-        return series.groupby(series.index.date).apply(
-            lambda x: self._convert_date_to_target_granularity(x, target_granularity, quantity_type)
-        ).droplevel(0).rename_axis(series.index.name).rename(series.name)
-
-    def _convert_date_to_target_granularity(
         self,
-        series: pd.Series,
-        target_granularity: pd.Timedelta,
-        quantity_type: QuantityTypeEnum
-    ) -> pd.Series:
-        """Convert granularity for a single date's worth of data.
-        
-        This internal method handles the actual conversion logic for data within
-        a single date range. It determines whether upsampling, downsampling, or
-        no conversion is needed, then applies the appropriate method.
-        
-        Args:
-            series: Time series data for a single date (may span into next date)
-            target_granularity: Target granularity as Timedelta
-            quantity_type: Type of quantity for scaling decisions
-            
-        Returns:
-            Converted series for the date period
-            
-        Raises:
-            GranularityConversionError: If conversion parameters are invalid or
-                                       unsupported granularities are encountered
+        data: pd.DataFrame | pd.Series,
+        target_index: pd.DatetimeIndex,
+        quantity_type: QuantityTypeEnum,
+    ) -> pd.DataFrame | pd.Series:
+        """Convert data to match a specific target DatetimeIndex.
+
+        Derives the target frequency from the index, converts, then reindexes
+        to ensure the output aligns exactly with the requested timestamps.
         """
-        if len(set(series.index.date)) > 2:
-            raise GranularityConversionError('This method is intended for single-date conversion only.')
-        source_gran = self._non_strict_gran_analyzer.get_granularity_as_series_of_minutes(series.index)
-        if len(source_gran.unique()) > 1:
-            raise GranularityConversionError('Cannot convert data with changing granularity within a single day.')
-        source_gran_minutes = source_gran.values[0]
-        target_gran_minutes = target_granularity.total_seconds() / 60
+        target_freq = target_index.to_series().diff().median()
+        result = self.convert(data, target_freq, quantity_type)
+        return result.reindex(target_index)
 
-        _allowed_granularities = [1, 5, 15, 30, 60, 24*60]
-        if target_gran_minutes not in _allowed_granularities:
-            raise GranularityConversionError(
-                f'Target granularity {target_gran_minutes} minutes not supported. '
-                f'Allowed granularities: {_allowed_granularities} minutes'
-            )
+    def upsample_through_fillna(
+        self,
+        data: pd.DataFrame | pd.Series,
+        quantity_type: QuantityTypeEnum,
+    ) -> pd.DataFrame | pd.Series:
+        """Fill sparse columns at the existing index frequency.
 
-        if target_gran_minutes > source_gran_minutes:
-            sampling = SamplingMethodEnum.DOWNSAMPLING
-        elif target_gran_minutes < source_gran_minutes:
-            sampling = SamplingMethodEnum.UPSAMPLING
-        else:
-            sampling = SamplingMethodEnum.KEEP
+        For DataFrames where some columns have coarser data (NaN at intermediate
+        timestamps), this fills the gaps respecting the quantity type — replicating
+        for intensive quantities, distributing for extensive quantities.
+        """
+        freq = data.index.to_series().diff().min()
+        return self.convert(data, freq, quantity_type)
 
-        if sampling == SamplingMethodEnum.UPSAMPLING:
-            scaling_factor = source_gran_minutes / target_gran_minutes
-            if (scaling_factor % 1) != 0:
-                raise GranularityConversionError(
-                    f'Source granularity ({source_gran_minutes} min) is not evenly divisible '
-                    f'by target granularity ({target_gran_minutes} min)'
-                )
-            else:
-                scaling_factor = int(scaling_factor)
+    # kept for backward compatibility
+    def convert_to_target_granularity(
+        self,
+        data: pd.DataFrame | pd.Series,
+        target_granularity: pd.Timedelta,
+        quantity_type: QuantityTypeEnum,
+    ) -> pd.DataFrame | pd.Series:
+        return self.convert(data, target_granularity, quantity_type)
 
-            new_index = pd.date_range(
-                start=series.index[0],
-                end=series.index[-1],
-                freq=f"{target_gran_minutes}min",
-                tz=series.index.tz
-            )
+    # ── internals ────────────────────────────────────────────────────────
 
-            # For intensive quantities, replicate values; for extensive, divide by scaling factor
-            if quantity_type == QuantityTypeEnum.INTENSIVE:
-                return series.reindex(new_index, method='ffill')
-            else:  # EXTENSIVE
-                return series.reindex(new_index, method='ffill') / scaling_factor
+    @staticmethod
+    def _downsample(
+        df: pd.DataFrame,
+        target_td: pd.Timedelta,
+        quantity_type: QuantityTypeEnum,
+    ) -> pd.DataFrame:
+        resampler = df.resample(target_td)
+        if quantity_type == QuantityTypeEnum.EXTENSIVE:
+            return resampler.sum(min_count=1)
+        return resampler.mean()
 
-        elif sampling == SamplingMethodEnum.DOWNSAMPLING:
-            groups = series.groupby(pd.Grouper(freq=f"{target_gran_minutes}min"))
-            # For extensive quantities, sum the values; for intensive, take the mean
-            func = 'sum' if quantity_type == QuantityTypeEnum.EXTENSIVE else 'mean'
-            return groups.agg(func)
-        
-        else:  # SamplingMethodEnum.KEEP
-            return series
+    @staticmethod
+    def _upsample(
+        df: pd.DataFrame,
+        target_td: pd.Timedelta,
+        quantity_type: QuantityTypeEnum,
+    ) -> pd.DataFrame:
+        resampled = df.resample(target_td).asfreq()
+        days = resampled.index.normalize()
 
-        return series
+        if quantity_type == QuantityTypeEnum.INTENSIVE:
+            return resampled.groupby(days).ffill()
+
+        # Extensive: forward-fill within days, then divide by spread factor.
+        # Each non-NaN value starts a new "segment" (via cumsum of the notna mask).
+        # The segment size tells us over how many target periods the original value
+        # was spread — that's the divisor.  Columns already at the target frequency
+        # have segment size 1 everywhere, so they pass through unchanged.
+        filled = resampled.groupby(days).ffill()
+        segments = resampled.notna().cumsum()
+        spread = segments.apply(
+            lambda col: col.groupby([days, col]).transform('size')
+        )
+        return filled / spread
 
 
 if __name__ == '__main__':
@@ -325,24 +156,39 @@ if __name__ == '__main__':
     hourly_index = pd.date_range('2024-01-01', '2024-12-31 23:45', freq='h', tz=tz)
     quarter_hourly_index = pd.date_range('2024-01-01', '2024-12-31 23:45', freq='15min', tz=tz)
 
+    # ── basic Series round-trips ──
     for qt in [QuantityTypeEnum.INTENSIVE, QuantityTypeEnum.EXTENSIVE]:
         for idx in [hourly_index, quarter_hourly_index]:
             series = pd.Series(100, index=idx)
             series = series.loc[series.index.difference(series.loc['2024-02'].index)]
-            print(f'{qt} series: \n{series}')
-            for target in [15, 60]:
+            print(f'{qt} series:\n{series}')
+            for target in ['15min', '1h']:
                 start = time.time()
-                ts = converter.convert_to_target_granularity(series, pd.Timedelta(minutes=target), qt)
-                print(f'To granularity {target}min took {time.time()-start:.2f} seconds:\n{ts}')
+                ts = converter.convert(series, target, qt)
+                print(f'  → {target} took {time.time()-start:.2f}s:\n{ts}')
             for target_idx in [hourly_index, quarter_hourly_index]:
                 start = time.time()
                 ts = converter.convert_to_target_index(series, target_idx, qt)
-                print(f'To target idx {target_idx[:2]} min took {time.time()-start:.2f} seconds:\n{ts}')
+                print(f'  → target idx took {time.time()-start:.2f}s:\n{ts}')
 
-    # Test fillna upsampling
-    _values = [100, np.nan, np.nan, np.nan, 200, np.nan, 300, np.nan, 50, np.nan, np.nan, np.nan, np.nan, np.nan]
+    # ── mixed-granularity DataFrame ──
+    print('\n── mixed-granularity DataFrame ──')
+    df = pd.DataFrame({
+        'hourly_col': pd.Series(100, index=hourly_index),
+        'qh_col': pd.Series(10, index=quarter_hourly_index),
+    })
+    print(f'Mixed DF shape: {df.shape}, NaN count:\n{df.isna().sum()}')
+    for qt in [QuantityTypeEnum.INTENSIVE, QuantityTypeEnum.EXTENSIVE]:
+        start = time.time()
+        result = converter.convert(df, '15min', qt)
+        print(f'{qt} → 15min took {time.time()-start:.2f}s, shape={result.shape}')
+        print(result.head(8))
+
+    # ── fillna upsampling ──
+    print('\n── upsample_through_fillna ──')
+    _values = [100, np.nan, np.nan, np.nan, 200, np.nan, 300, np.nan,
+               50, np.nan, np.nan, np.nan, np.nan, np.nan]
     mixed_series = pd.Series(_values, index=quarter_hourly_index[:len(_values)])
-
     for qt in [QuantityTypeEnum.INTENSIVE, QuantityTypeEnum.EXTENSIVE]:
         ts = converter.upsample_through_fillna(mixed_series, qt)
         print(f'Upsampled as {qt}:\n{ts}')

--- a/mesqual/energy_data_handling/granularity_converter.py
+++ b/mesqual/energy_data_handling/granularity_converter.py
@@ -62,6 +62,9 @@ class TimeSeriesGranularityConverter:
 
         target_td = target_freq if isinstance(target_freq, pd.Timedelta) else pd.Timedelta(target_freq)
 
+        if df.empty:
+            return data.copy() if is_series else df.copy()
+
         # Determine sampling direction per day based on each day's median index step
         dates = pd.Series(df.index.date, index=df.index)
         day_gran = pd.to_timedelta(
@@ -69,8 +72,10 @@ class TimeSeriesGranularityConverter:
         )
 
         direction = pd.Series(SamplingMethodEnum.KEEP, index=df.index)
-        direction[day_gran > target_td] = SamplingMethodEnum.UPSAMPLING
-        direction[day_gran < target_td] = SamplingMethodEnum.DOWNSAMPLING
+        # NaT from single-row days stays KEEP (no conversion possible)
+        non_nat = day_gran.notna()
+        direction[(day_gran > target_td) & non_nat] = SamplingMethodEnum.UPSAMPLING
+        direction[(day_gran < target_td) & non_nat] = SamplingMethodEnum.DOWNSAMPLING
 
         # KEEP days with sparse columns (NaN) still need filling
         keep_mask = direction == SamplingMethodEnum.KEEP

--- a/mesqual/energy_data_handling/granularity_converter.py
+++ b/mesqual/energy_data_handling/granularity_converter.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+import numpy as np
 import pandas as pd
 
 from mesqual.enums import QuantityTypeEnum
@@ -34,7 +35,9 @@ class TimeSeriesGranularityConverter:
     contiguous blocks of the same direction are processed together.
 
     Uses pandas resample directly, avoiding explicit granularity analysis of the source data.
-    Forward-fill is bounded per calendar day to prevent bleeding across data gaps.
+    Forward-fill is bounded by ``fill_boundary`` (calendar day by default) to prevent
+    bleeding across data gaps. The boundary is configurable — e.g. "h" to stop fill at
+    each hour, "M" to allow fill across days within a month, or None to fill unbounded.
     """
 
     def convert(
@@ -42,6 +45,7 @@ class TimeSeriesGranularityConverter:
         data: pd.DataFrame | pd.Series,
         target_freq: str | pd.Timedelta,
         quantity_type: QuantityTypeEnum,
+        fill_boundary: str | pd.Timedelta | None = 'D',
     ) -> pd.DataFrame | pd.Series:
         """Convert time series data to a target frequency.
 
@@ -50,6 +54,13 @@ class TimeSeriesGranularityConverter:
             target_freq: Target frequency as a Timedelta or timedelta-compatible string
                          (e.g., "15min", "1h", pd.Timedelta(hours=1)).
             quantity_type: INTENSIVE (prices, power) or EXTENSIVE (volumes, welfare).
+            fill_boundary: Granularity at which forward-fill is bounded when upsampling
+                           — the fill never bleeds across a change in this boundary, and
+                           resample-fabricated rows outside the input's boundaries are
+                           dropped. A fixed offset / Timedelta ("15min", "h", "D") or a
+                           calendar period alias ("W", "M", "Q", "Y"). Defaults to "D"
+                           (per calendar day). None fills unbounded across the whole
+                           series.
 
         Returns:
             Converted data, same type as input (Series or DataFrame).
@@ -65,11 +76,16 @@ class TimeSeriesGranularityConverter:
         if df.empty:
             return data.copy() if is_series else df.copy()
 
-        # Determine sampling direction per day based on each day's median index step
+        # Determine sampling direction per day based on each day's median index step.
+        # This only picks the resample direction; how far fill reaches is set by
+        # fill_boundary (see _upsample / _apply).
         dates = pd.Series(df.index.date, index=df.index)
-        day_gran = pd.to_timedelta(
-            df.index.to_series().groupby(dates).transform(lambda g: g.diff().median())
-        )
+        day_steps = df.index.to_series().groupby(dates).transform(lambda g: g.diff().median())
+        if pd.api.types.is_datetime64_any_dtype(day_steps):
+            # Every day had a single row → all-NaT, which pandas infers as datetime64.
+            day_gran = pd.Series(pd.NaT, index=df.index, dtype='timedelta64[ns]')
+        else:
+            day_gran = pd.to_timedelta(day_steps)
 
         direction = pd.Series(SamplingMethodEnum.KEEP, index=df.index)
         # NaT from single-row days stays KEEP (no conversion possible)
@@ -85,7 +101,7 @@ class TimeSeriesGranularityConverter:
         # Fast path: uniform direction across the entire series
         unique_dirs = direction.unique()
         if len(unique_dirs) == 1:
-            result = self._apply(df, unique_dirs[0], target_td, quantity_type)
+            result = self._apply(df, unique_dirs[0], target_td, quantity_type, fill_boundary)
         else:
             # Process contiguous blocks of the same direction separately
             # so that resample doesn't create spurious entries in the gaps
@@ -93,7 +109,7 @@ class TimeSeriesGranularityConverter:
             parts = []
             for _, block_rows in direction.groupby(block_ids):
                 block = df.loc[block_rows.index]
-                parts.append(self._apply(block, block_rows.iloc[0], target_td, quantity_type))
+                parts.append(self._apply(block, block_rows.iloc[0], target_td, quantity_type, fill_boundary))
             result = pd.concat(parts).sort_index()
 
         if is_series:
@@ -105,6 +121,7 @@ class TimeSeriesGranularityConverter:
         data: pd.DataFrame | pd.Series,
         target_index: pd.DatetimeIndex,
         quantity_type: QuantityTypeEnum,
+        fill_boundary: str | pd.Timedelta | None = 'D',
     ) -> pd.DataFrame | pd.Series:
         """Convert data to match a specific target DatetimeIndex.
 
@@ -112,13 +129,14 @@ class TimeSeriesGranularityConverter:
         to ensure the output aligns exactly with the requested timestamps.
         """
         target_freq = target_index.to_series().diff().median()
-        result = self.convert(data, target_freq, quantity_type)
+        result = self.convert(data, target_freq, quantity_type, fill_boundary)
         return result.reindex(target_index)
 
     def upsample_through_fillna(
         self,
         data: pd.DataFrame | pd.Series,
         quantity_type: QuantityTypeEnum,
+        fill_boundary: str | pd.Timedelta | None = 'D',
     ) -> pd.DataFrame | pd.Series:
         """Fill sparse columns at the existing index frequency.
 
@@ -127,7 +145,7 @@ class TimeSeriesGranularityConverter:
         for intensive quantities, distributing for extensive quantities.
         """
         freq = data.index.to_series().diff().min()
-        return self.convert(data, freq, quantity_type)
+        return self.convert(data, freq, quantity_type, fill_boundary)
 
     # kept for backward compatibility
     def convert_to_target_granularity(
@@ -135,8 +153,9 @@ class TimeSeriesGranularityConverter:
         data: pd.DataFrame | pd.Series,
         target_granularity: pd.Timedelta,
         quantity_type: QuantityTypeEnum,
+        fill_boundary: str | pd.Timedelta | None = 'D',
     ) -> pd.DataFrame | pd.Series:
-        return self.convert(data, target_granularity, quantity_type)
+        return self.convert(data, target_granularity, quantity_type, fill_boundary)
 
     # ── internals ────────────────────────────────────────────────────────
 
@@ -146,17 +165,19 @@ class TimeSeriesGranularityConverter:
         direction: SamplingMethodEnum,
         target_td: pd.Timedelta,
         quantity_type: QuantityTypeEnum,
+        fill_boundary: str | pd.Timedelta | None,
     ) -> pd.DataFrame:
         if direction == SamplingMethodEnum.KEEP:
             return df
         if direction == SamplingMethodEnum.UPSAMPLING:
-            result = self._upsample(df, target_td, quantity_type)
+            result = self._upsample(df, target_td, quantity_type, fill_boundary)
         else:
             result = self._downsample(df, target_td, quantity_type)
         # resample() builds a contiguous grid between min and max of the input,
-        # fabricating rows on calendar days that weren't present. Drop those.
-        input_days = df.index.normalize().unique()
-        return result[result.index.normalize().isin(input_days)]
+        # fabricating rows in boundaries that weren't present. Drop those.
+        input_bounds = pd.Index(self._boundary_keys(df.index, fill_boundary)).unique()
+        result_bounds = pd.Index(self._boundary_keys(result.index, fill_boundary))
+        return result[result_bounds.isin(input_bounds)]
 
     @staticmethod
     def _downsample(
@@ -169,29 +190,53 @@ class TimeSeriesGranularityConverter:
             return resampler.sum(min_count=1)
         return resampler.mean()
 
-    @staticmethod
     def _upsample(
+        self,
         df: pd.DataFrame,
         target_td: pd.Timedelta,
         quantity_type: QuantityTypeEnum,
+        fill_boundary: str | pd.Timedelta | None,
     ) -> pd.DataFrame:
         resampled = df.resample(target_td).asfreq()
-        days = resampled.index.normalize()
+        bound = self._boundary_keys(resampled.index, fill_boundary)
 
         if quantity_type == QuantityTypeEnum.INTENSIVE:
-            return resampled.groupby(days).ffill()
+            return resampled.groupby(bound).ffill()
 
-        # Extensive: forward-fill within days, then divide by spread factor.
+        # Extensive: forward-fill within each boundary, then divide by spread factor.
         # Each non-NaN value starts a new "segment" (via cumsum of the notna mask).
         # The segment size tells us over how many target periods the original value
         # was spread — that's the divisor.  Columns already at the target frequency
         # have segment size 1 everywhere, so they pass through unchanged.
-        filled = resampled.groupby(days).ffill()
+        filled = resampled.groupby(bound).ffill()
         segments = resampled.notna().cumsum()
         spread = segments.apply(
-            lambda col: col.groupby([days, col]).transform('size')
+            lambda col: col.groupby([bound, col]).transform('size')
         )
         return filled / spread
+
+    @staticmethod
+    def _boundary_keys(
+        index: pd.DatetimeIndex,
+        boundary: str | pd.Timedelta | None,
+    ):
+        """Per-row grouping keys that bound forward-fill and sampling direction.
+
+        Fill never bleeds across a change in these keys. ``None`` yields a single
+        group, i.e. fill is unbounded across the whole series.
+
+        Keys are computed on tz-naive wall-clock time so that flooring never hits
+        DST-ambiguous instants (e.g. the autumn fall-back hour).
+        """
+        if boundary is None:
+            return np.zeros(len(index), dtype=int)
+        if index.tz is not None:
+            index = index.tz_localize(None)
+        try:
+            return index.floor(boundary)
+        except (ValueError, TypeError):
+            # Non-fixed calendar frequency (week, month, quarter, year)
+            return index.to_period(boundary)
 
 
 if __name__ == '__main__':
@@ -257,3 +302,10 @@ if __name__ == '__main__':
             # Verify: check a few values from each part
             print(f'    Jan sample: {ts.iloc[:4].values}')
             print(f'    Jul sample: {ts.loc["2024-07-01"].iloc[:4].values}')
+
+    # ── configurable fill_boundary ──
+    print('\n── configurable fill_boundary ──')
+    sparse = pd.Series([100.0, 200.0], index=pd.to_datetime(['2024-01-01 10:00', '2024-01-01 12:00']))
+    for fb in ['D', 'h', None]:
+        ts = converter.convert(sparse, '15min', QuantityTypeEnum.INTENSIVE, fill_boundary=fb)
+        print(f'  fill_boundary={fb!r}: len={len(ts)} (11:xx filled={11 in ts.index.hour})')

--- a/mesqual/energy_data_handling/granularity_converter.py
+++ b/mesqual/energy_data_handling/granularity_converter.py
@@ -64,7 +64,9 @@ class TimeSeriesGranularityConverter:
 
         # Determine sampling direction per day based on each day's median index step
         dates = pd.Series(df.index.date, index=df.index)
-        day_gran = df.index.to_series().groupby(dates).transform(lambda g: g.diff().median())
+        day_gran = pd.to_timedelta(
+            df.index.to_series().groupby(dates).transform(lambda g: g.diff().median())
+        )
 
         direction = pd.Series(SamplingMethodEnum.KEEP, index=df.index)
         direction[day_gran > target_td] = SamplingMethodEnum.UPSAMPLING

--- a/mesqual/energy_data_handling/granularity_converter.py
+++ b/mesqual/energy_data_handling/granularity_converter.py
@@ -29,6 +29,10 @@ class TimeSeriesGranularityConverter:
     The conversion is applied per-column — columns already at the target frequency
     pass through unchanged.
 
+    Supports time series with granularity transitions (e.g., hourly before Oct 2025,
+    15-min after). The sampling direction is determined per calendar day, and
+    contiguous blocks of the same direction are processed together.
+
     Uses pandas resample directly, avoiding explicit granularity analysis of the source data.
     Forward-fill is bounded per calendar day to prevent bleeding across data gaps.
     """
@@ -57,14 +61,33 @@ class TimeSeriesGranularityConverter:
             raise TypeError(f"Index must be DatetimeIndex, got {type(df.index)}")
 
         target_td = target_freq if isinstance(target_freq, pd.Timedelta) else pd.Timedelta(target_freq)
-        index_step = df.index.to_series().diff().median()
 
-        if target_td > index_step:
-            result = self._downsample(df, target_td, quantity_type)
-        elif target_td < index_step or df.isna().any().any():
-            result = self._upsample(df, target_td, quantity_type)
+        # Determine sampling direction per day based on each day's median index step
+        dates = pd.Series(df.index.date, index=df.index)
+        day_gran = df.index.to_series().groupby(dates).transform(lambda g: g.diff().median())
+
+        direction = pd.Series(SamplingMethodEnum.KEEP, index=df.index)
+        direction[day_gran > target_td] = SamplingMethodEnum.UPSAMPLING
+        direction[day_gran < target_td] = SamplingMethodEnum.DOWNSAMPLING
+
+        # KEEP days with sparse columns (NaN) still need filling
+        keep_mask = direction == SamplingMethodEnum.KEEP
+        if keep_mask.any() and df[keep_mask].isna().any().any():
+            direction[keep_mask] = SamplingMethodEnum.UPSAMPLING
+
+        # Fast path: uniform direction across the entire series
+        unique_dirs = direction.unique()
+        if len(unique_dirs) == 1:
+            result = self._apply(df, unique_dirs[0], target_td, quantity_type)
         else:
-            result = df
+            # Process contiguous blocks of the same direction separately
+            # so that resample doesn't create spurious entries in the gaps
+            block_ids = (direction != direction.shift()).cumsum()
+            parts = []
+            for _, block_rows in direction.groupby(block_ids):
+                block = df.loc[block_rows.index]
+                parts.append(self._apply(block, block_rows.iloc[0], target_td, quantity_type))
+            result = pd.concat(parts).sort_index()
 
         if is_series:
             return result.iloc[:, 0].rename(data.name)
@@ -109,6 +132,19 @@ class TimeSeriesGranularityConverter:
         return self.convert(data, target_granularity, quantity_type)
 
     # ── internals ────────────────────────────────────────────────────────
+
+    def _apply(
+        self,
+        df: pd.DataFrame,
+        direction: SamplingMethodEnum,
+        target_td: pd.Timedelta,
+        quantity_type: QuantityTypeEnum,
+    ) -> pd.DataFrame:
+        if direction == SamplingMethodEnum.UPSAMPLING:
+            return self._upsample(df, target_td, quantity_type)
+        if direction == SamplingMethodEnum.DOWNSAMPLING:
+            return self._downsample(df, target_td, quantity_type)
+        return df
 
     @staticmethod
     def _downsample(
@@ -192,3 +228,20 @@ if __name__ == '__main__':
     for qt in [QuantityTypeEnum.INTENSIVE, QuantityTypeEnum.EXTENSIVE]:
         ts = converter.upsample_through_fillna(mixed_series, qt)
         print(f'Upsampled as {qt}:\n{ts}')
+
+    # ── mixed-granularity time series (hourly Jan-Jun, 15min Jul-Dec) ──
+    print('\n── mixed-granularity time series (simulating mid-year resolution change) ──')
+    hourly_part = pd.Series(100, index=pd.date_range('2024-01-01', '2024-06-30 23:00', freq='h', tz=tz))
+    qh_part = pd.Series(10, index=pd.date_range('2024-07-01', '2024-12-31 23:45', freq='15min', tz=tz))
+    mixed_series = pd.concat([hourly_part, qh_part])
+    print(f'Mixed series length: {len(mixed_series)}')
+    print(f'  hourly part: {len(hourly_part)}, 15min part: {len(qh_part)}')
+
+    for qt in [QuantityTypeEnum.INTENSIVE, QuantityTypeEnum.EXTENSIVE]:
+        for target in ['15min', '1h']:
+            start = time.time()
+            ts = converter.convert(mixed_series, target, qt)
+            print(f'  {qt} → {target} took {time.time()-start:.2f}s, len={len(ts)}')
+            # Verify: check a few values from each part
+            print(f'    Jan sample: {ts.iloc[:4].values}')
+            print(f'    Jul sample: {ts.loc["2024-07-01"].iloc[:4].values}')

--- a/mesqual/energy_data_handling/granularity_converter.py
+++ b/mesqual/energy_data_handling/granularity_converter.py
@@ -147,11 +147,16 @@ class TimeSeriesGranularityConverter:
         target_td: pd.Timedelta,
         quantity_type: QuantityTypeEnum,
     ) -> pd.DataFrame:
+        if direction == SamplingMethodEnum.KEEP:
+            return df
         if direction == SamplingMethodEnum.UPSAMPLING:
-            return self._upsample(df, target_td, quantity_type)
-        if direction == SamplingMethodEnum.DOWNSAMPLING:
-            return self._downsample(df, target_td, quantity_type)
-        return df
+            result = self._upsample(df, target_td, quantity_type)
+        else:
+            result = self._downsample(df, target_td, quantity_type)
+        # resample() builds a contiguous grid between min and max of the input,
+        # fabricating rows on calendar days that weren't present. Drop those.
+        input_days = df.index.normalize().unique()
+        return result[result.index.normalize().isin(input_days)]
 
     @staticmethod
     def _downsample(

--- a/mesqual/energy_data_handling/variable_utils/regional_trade_balance_calculator.py
+++ b/mesqual/energy_data_handling/variable_utils/regional_trade_balance_calculator.py
@@ -47,7 +47,8 @@ class RegionalTradeBalanceCalculator:
     EXP_VAR = "exp"
     IMP_VAR = "imp"
     NET_EXP_VAR = "net_exp"
-    ALL_VARS = [EXP_VAR, IMP_VAR, NET_EXP_VAR]
+    TOTAL_VAR = "total"
+    ALL_VARS = [EXP_VAR, IMP_VAR, NET_EXP_VAR, TOTAL_VAR]
 
     def __init__(
             self,
@@ -122,11 +123,14 @@ class RegionalTradeBalanceCalculator:
         for primary in self.get_all_regions():
             for secondary in self.get_region_neighbors(primary):
                 net_exp = self._get_net_exp_for_couple(primary, secondary, flow_data, flow_type)
+                _exp = net_exp.clip(0)
+                _imp = net_exp.clip(None, 0).abs()
                 df = pd.concat(
                     {
                         (primary, secondary, self.NET_EXP_VAR): net_exp,
-                        (primary, secondary, self.EXP_VAR): net_exp.clip(0),
-                        (primary, secondary, self.IMP_VAR): net_exp.clip(None, 0).abs(),
+                        (primary, secondary, self.EXP_VAR): _exp,
+                        (primary, secondary, self.IMP_VAR): _imp,
+                        (primary, secondary, self.TOTAL_VAR): _exp + _imp,
                     },
                     axis=1,
                     names=column_level_names,

--- a/mesqual/energy_data_handling/variable_utils/regional_trade_balance_calculator.py
+++ b/mesqual/energy_data_handling/variable_utils/regional_trade_balance_calculator.py
@@ -98,19 +98,26 @@ class RegionalTradeBalanceCalculator:
         lines_backward = self.line_model_df[mask_backward].index
 
         if flow_type == FlowType.PRE_LOSS:
-            return (
-                    flow_data.sent_up[lines_forward].sum(axis=1) -
-                    flow_data.sent_down[lines_forward].sum(axis=1) +
-                    flow_data.sent_down[lines_backward].sum(axis=1) -
-                    flow_data.sent_up[lines_backward].sum(axis=1)
-            )
+            fwd_in, fwd_out = flow_data.sent_up, flow_data.sent_down
+            bwd_in, bwd_out = flow_data.sent_down, flow_data.sent_up
         else:  # POST_LOSS
-            return (
-                    flow_data.sent_up[lines_forward].sum(axis=1) -
-                    flow_data.received_down[lines_forward].sum(axis=1) +
-                    flow_data.sent_down[lines_backward].sum(axis=1) -
-                    flow_data.received_up[lines_backward].sum(axis=1)
-            )
+            fwd_in, fwd_out = flow_data.sent_up, flow_data.received_down
+            bwd_in, bwd_out = flow_data.sent_down, flow_data.received_up
+
+        net = (
+                fwd_in[lines_forward].sum(axis=1) -
+                fwd_out[lines_forward].sum(axis=1) +
+                bwd_in[lines_backward].sum(axis=1) -
+                bwd_out[lines_backward].sum(axis=1)
+        )
+
+        any_value = (
+                fwd_in[lines_forward].notna().any(axis=1) |
+                fwd_out[lines_forward].notna().any(axis=1) |
+                bwd_in[lines_backward].notna().any(axis=1) |
+                bwd_out[lines_backward].notna().any(axis=1)
+        )
+        return net.where(any_value)
 
     def get_trade_balance(
             self,
@@ -166,7 +173,7 @@ class RegionalTradeBalanceCalculator:
         if trade_balance_df.columns.names != [self.primary_name, self.partner_name, "variable"]:
             raise ValueError("Input DataFrame must be in format from aggregate_flows")
 
-        return trade_balance_df.T.groupby(level=[self.primary_name, "variable"]).sum().T
+        return trade_balance_df.T.groupby(level=[self.primary_name, "variable"]).sum(min_count=1).T
 
     def get_net_position_per_primary_level(self, trade_balance_df: pd.DataFrame) -> pd.DataFrame:
         return self.aggregate_trade_balance_to_primary_level(trade_balance_df).xs(self.NET_EXP_VAR, level=-1, axis=1)

--- a/mesqual/enums.py
+++ b/mesqual/enums.py
@@ -45,6 +45,7 @@ class QuantityTypeEnum(Enum):
 
     INTENSIVE = "intensive"  # price, power, flow rate
     EXTENSIVE = "extensive"  # welfare, volume, energy
+    UNKNOWN = "unknown"
 
 
 class ComparisonTypeEnum(Enum):

--- a/mesqual/flag/flag_index.py
+++ b/mesqual/flag/flag_index.py
@@ -266,7 +266,10 @@ class FlagIndex(Generic[FlagType], ABC):
             >>> flag_index.get_quantity_type_enum("Storage.energy_nom")  # MWh
             QuantityTypeEnum.EXTENSIVE
         """
-        unit = self.get_unit(flag)
+        try:
+            unit = self.get_unit(flag)
+        except KeyError as e:
+            raise KeyError(f'Exception during handling {flag}: {e}')
         return Units.get_quantity_type_enum(unit)
 
     def get_all_timeseries_flags_for_model_flag(self, dataset: Dataset, flag: FlagType) -> Set[FlagType]:

--- a/mesqual/flag/flag_index.py
+++ b/mesqual/flag/flag_index.py
@@ -266,11 +266,8 @@ class FlagIndex(Generic[FlagType], ABC):
             >>> flag_index.get_quantity_type_enum("Storage.energy_nom")  # MWh
             QuantityTypeEnum.EXTENSIVE
         """
-        try:
-            unit = self.get_unit(flag)
-            return Units.get_quantity_type_enum(unit)
-        except KeyError as e:
-            raise KeyError(f'Exception during handling {flag}: {e}')
+        unit = self.get_unit(flag)
+        return Units.get_quantity_type_enum(unit)
 
     def get_all_timeseries_flags_for_model_flag(self, dataset: Dataset, flag: FlagType) -> Set[FlagType]:
         """

--- a/mesqual/flag/flag_index.py
+++ b/mesqual/flag/flag_index.py
@@ -268,9 +268,9 @@ class FlagIndex(Generic[FlagType], ABC):
         """
         try:
             unit = self.get_unit(flag)
+            return Units.get_quantity_type_enum(unit)
         except KeyError as e:
             raise KeyError(f'Exception during handling {flag}: {e}')
-        return Units.get_quantity_type_enum(unit)
 
     def get_all_timeseries_flags_for_model_flag(self, dataset: Dataset, flag: FlagType) -> Set[FlagType]:
         """

--- a/mesqual/kpis/aggregations.py
+++ b/mesqual/kpis/aggregations.py
@@ -315,6 +315,11 @@ class ValueComparisons:
         lambda var, ref: np.inf * np.sign(var) if ref == 0 else var / ref * 100,
         Units.percent
     )
+    Ratio = ValueComparison(
+        "Ratio",
+        lambda var, ref: np.inf * np.sign(var) if ref == 0 else var / ref * 100,
+        Units.ratio
+    )
     Delta = ValueComparison("Delta", lambda var, ref: var - ref)
     Diff = ValueComparison("Diff", lambda var, ref: var - ref)
 

--- a/mesqual/study_manager.py
+++ b/mesqual/study_manager.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from mesqual.datasets.dataset_collection import DatasetConcatCollection, Dataset
 from mesqual.datasets.dataset_comparison import DatasetComparison, DatasetConcatCollectionOfComparisons
@@ -149,7 +150,7 @@ class StudyManager:
             self,
             scenarios: DatasetConcatCollection,
             comparisons: DatasetConcatCollectionOfComparisons,
-            export_folder: str = None,
+            study_folder: str | Path = None,
     ):
         self._scenarios = scenarios
         self._comparisons = comparisons
@@ -161,9 +162,7 @@ class StudyManager:
             name='scenarios_and_comparisons',
             concat_level_name='type',
         )
-        self._export_folder: str = export_folder
-        if export_folder is not None:
-            self._ensure_folder_exists(export_folder)
+        self._study_folder = Path(study_folder) if study_folder is not None else study_folder
 
     @property
     def scen(self) -> DatasetConcatCollection:
@@ -184,29 +183,21 @@ class StudyManager:
         return self._scenarios_and_comparisons
 
     @property
-    def export_folder(self) -> str:
-        return self._export_folder
-
-    @export_folder.setter
-    def export_folder(self, folder_path: str):
-        self._ensure_folder_exists(folder_path)
-        self._export_folder = folder_path
-
-    @staticmethod
-    def _ensure_folder_exists(folder: str):
-        os.makedirs(folder, exist_ok=True)
-
-    def export_path(self, file_name: str) -> str:
-        if self._export_folder is None:
+    def study_folder(self) -> Path:
+        if self._study_folder is None:
             raise RuntimeError(f'Export folder must be assigned first.')
-        return os.path.join(self._export_folder, file_name)
+        return self._study_folder
+
+    @study_folder.setter
+    def study_folder(self, folder_path: str | Path):
+        self._study_folder = folder_path
 
     @classmethod
     def factory_from_scenarios(
             cls,
             scenarios: list[Dataset],
             comparisons: list[tuple[str, str]],
-            export_folder: str = None
+            study_folder: str | Path = None
     ) -> 'StudyManager':
         scen = DatasetConcatCollection(scenarios, name='scenario', concat_level_name='dataset',)
         comp = DatasetConcatCollectionOfComparisons(
@@ -217,4 +208,4 @@ class StudyManager:
             name='comparison',
             concat_level_name='dataset',
         )
-        return cls(scen, comp, export_folder)
+        return cls(scen, comp, study_folder)

--- a/mesqual/units.py
+++ b/mesqual/units.py
@@ -197,7 +197,7 @@ class Units(metaclass=_IterableUnitsMeta):
             unit: The unit to classify
 
         Returns:
-            QuantityTypeEnum indicating INTENSIVE or EXTENSIVE
+            QuantityTypeEnum indicating INTENSIVE or EXTENSIVE (or UNKNOWN)
 
         Raises:
             KeyError: If the unit's base unit is not registered in the classification lists
@@ -213,7 +213,7 @@ class Units(metaclass=_IterableUnitsMeta):
             return QuantityTypeEnum.INTENSIVE
         elif base_unit in cls._EXTENSIVE_QUANTITIES:
             return QuantityTypeEnum.EXTENSIVE
-        raise KeyError(f'QuantityTypeEnum for {unit} not registered')
+        return QuantityTypeEnum.UNKNOWN
 
     @classmethod
     def units_have_same_base(cls, unit_1: Unit, unit_2: Unit) -> bool:

--- a/mesqual/utils/intersect_dicts.py
+++ b/mesqual/utils/intersect_dicts.py
@@ -3,6 +3,8 @@ from typing import Iterable, Dict
 
 def get_intersection_of_dicts(dict_list: Iterable[Dict]) -> Dict:
     """Returns a dictionary with key/value pairs that all provided dictionaries have in common."""
+    if not dict_list:
+        return dict()
     set_list = [set(d.items()) for d in dict_list]
     common_items = set.intersection(*set_list)
     common_dict = dict(common_items)

--- a/mesqual/visualizations/folium_viz_system/kpi_collection_map_visualizer.py
+++ b/mesqual/visualizations/folium_viz_system/kpi_collection_map_visualizer.py
@@ -166,46 +166,48 @@ class KPIGroupingManager:
         Returns:
             List of KPICollection objects, each representing a logical group
         """
-        from mesqual.utils.dict_combinations import dict_combination_iterator
-
         attribute_sets = kpi_collection.get_all_kpi_attributes_and_value_sets(primitive_values=True)
-        relevant_attribute_sets = {
-            k: v for k, v in attribute_sets.items()
+        relevant_keys = [
+            k for k in attribute_sets.keys()
             if k not in self.kpi_attribute_keys_to_exclude_from_grouping
-        }
+        ]
 
-        ordered_keys = [k for k in self.kpi_attribute_sort_order if k in relevant_attribute_sets]
+        grouping_keys = (
+            [k for k in self.kpi_attribute_sort_order if k in relevant_keys]
+            + [k for k in relevant_keys if k not in self.kpi_attribute_sort_order]
+        )
 
-        # Build attribute value rankings
-        attribute_value_rank: dict[str, dict[str, int]] = {}
-        for attr in ordered_keys:
-            existing_values = set(relevant_attribute_sets.get(attr, []))
+        # Build attribute value rankings (used for sorting groups)
+        attribute_value_rank: dict[str, dict] = {}
+        for attr in grouping_keys:
+            existing_values = list(attribute_sets.get(attr, set()))
             manual_order = [v for v in self.kpi_attribute_category_orders.get(attr, []) if v in existing_values]
-            remaining = list(existing_values - set(manual_order))
+            remaining = [v for v in existing_values if v not in manual_order]
             try:
-                remaining = list(sorted(remaining))
+                remaining = sorted(remaining)
             except TypeError:
                 pass
             full_order = manual_order + remaining
             attribute_value_rank[attr] = {val: idx for idx, val in enumerate(full_order)}
 
-        def sorting_index(group_kwargs: dict[str, str]) -> tuple:
+        # Bucket each KPI by its actual attribute tuple. KPIs missing an attribute
+        # land in the None bucket for that key instead of being filtered out of
+        # every group — required when an attribute is set on some scenarios but
+        # not others (e.g. heterogeneous dataset_attributes across a study).
+        groups_by_key: dict[tuple, list] = {}
+        for kpi in kpi_collection:
+            attrs = kpi.attributes.as_dict(primitive_values=True)
+            key = tuple(attrs.get(k) for k in grouping_keys)
+            groups_by_key.setdefault(key, []).append(kpi)
+
+        def sorting_index(key: tuple) -> tuple:
             return tuple(
-                attribute_value_rank[attr].get(group_kwargs.get(attr), float("inf"))
-                for attr in ordered_keys
+                attribute_value_rank[attr].get(val, float("inf"))
+                for attr, val in zip(grouping_keys, key)
             )
 
-        # Create and sort groups
-        group_kwargs_list = list(dict_combination_iterator(relevant_attribute_sets))
-        group_kwargs_list.sort(key=sorting_index)
-
-        groups: list[KPICollection] = []
-        for group_kwargs in group_kwargs_list:
-            g = kpi_collection.filter(**group_kwargs)
-            if not g.empty:
-                groups.append(g)
-
-        return groups
+        sorted_keys = sorted(groups_by_key.keys(), key=sorting_index)
+        return [KPICollection(groups_by_key[k]) for k in sorted_keys]
 
     def get_feature_group_name(self, kpi_group: KPICollection) -> str:
         """

--- a/mesqual/visualizations/html_dashboard.py
+++ b/mesqual/visualizations/html_dashboard.py
@@ -41,9 +41,11 @@ class HTMLDashboardElement:
             height: str = '100%',
             name: str = None,
             tab: Union[str, Tuple[str, str], None] = None,
+            force_height: bool = False,
     ):
         self.element = element
         self.height = height
+        self.force_height = force_height
         self.name = name or str(id(self))
         if name is None:
             logger.info(f'No name passed for {type(self).__name__}. Automatically generated name: {self.name}')
@@ -96,14 +98,25 @@ class HTMLDashboard:
             height: str = '100%',
             name: str = None,
             tab: Union[str, Tuple[str, str], None] = None,
+            force_height: bool = False,
     ):
         """Add a Plotly figure to the dashboard.
 
         Args:
             fig: The Plotly figure to add.
             height: CSS height specification for the figure. Defaults to '100%'.
+                Only used as the rendered container height when ``force_height``
+                is True or when the figure has no explicit ``layout.height``.
             name: Unique identifier for the figure. If None, auto-generates.
             tab: Optional tab path (see :class:`HTMLDashboardElement`).
+            force_height: When True, the dashboard's ``height`` argument wins
+                and the figure's ``layout.height``/``layout.width`` are cleared
+                so the plot adapts to the container (e.g. ``height='100%'``
+                fits the tab, ``height='2000px'`` produces a fixed-pixel
+                container, parent's ``overflow: auto`` then handles scroll).
+                When False (default), the figure's intrinsic
+                ``layout.height``/``layout.width`` win and ``height`` is only
+                used as a fallback if those are unset.
 
         Example:
 
@@ -111,7 +124,7 @@ class HTMLDashboard:
             >>> fig = px.bar(x=["A", "B", "C"], y=[1, 3, 2])
             >>> dashboard.add_plotly_figure(fig, height="400px", name="my_bar_chart")
         """
-        element = HTMLDashboardElement(fig, height, name, tab=tab)
+        element = HTMLDashboardElement(fig, height, name, tab=tab, force_height=force_height)
         self.content[element.name] = element
 
     def add_html(self, html_string: str, name: str = None, tab: Union[str, Tuple[str, str], None] = None):
@@ -297,10 +310,20 @@ class HTMLDashboard:
 
     def _element_to_html(self, element: HTMLDashboardElement, plotly_js_included: bool) -> str:
         if isinstance(element.element, go.Figure):
-            return element.element.to_html(
+            fig = element.element
+            if element.force_height:
+                # Clone so we don't mutate the caller's figure, then strip
+                # explicit layout dimensions so plotly's `default_height`
+                # actually takes effect and the plot adapts to the container.
+                fig = go.Figure(fig.to_dict())
+                fig.layout.height = None
+                fig.layout.width = None
+                fig.layout.autosize = True
+            return fig.to_html(
                 include_plotlyjs=not plotly_js_included,
                 full_html=False,
                 default_height=element.height,
+                config={'responsive': element.force_height},
             )
         elif isinstance(element.element, str):
             return element.element
@@ -375,7 +398,7 @@ class HTMLDashboard:
         .dashboard-tab-content .js-plotly-plot,
         .dashboard-subtab-content .js-plotly-plot { width: 100% !important; flex: 1 1 0; min-height: 0; }
         .dashboard-tab-content .plotly-graph-div,
-        .dashboard-subtab-content .plotly-graph-div { height: 100% !important; }
+        .dashboard-subtab-content .plotly-graph-div { height: 100%; }
         """
 
     @staticmethod

--- a/mesqual/visualizations/html_dashboard.py
+++ b/mesqual/visualizations/html_dashboard.py
@@ -1,5 +1,6 @@
 import os
-from typing import List, Union, Dict, TYPE_CHECKING
+from typing import List, Union, Dict, Tuple, Optional, TYPE_CHECKING
+from collections import OrderedDict
 
 import plotly.graph_objects as go
 
@@ -22,23 +23,40 @@ class HTMLDashboardElement:
         element: The dashboard element content, either a Plotly figure or HTML string.
         height: CSS height specification for the element. Defaults to '100%'.
         name: Unique identifier for the element. If None, auto-generates using object id.
+        tab: Optional tab path. A string places the element in a top-level tab.
+            A tuple of two strings places it in a nested sub-tab, e.g.
+            ``("Market Results", "Volumes")``. If None, the element is ungrouped
+            (rendered at the top level in scroll mode, or placed in a default tab
+            in tabbed mode).
 
     Attributes:
         element: The stored dashboard element (figure or HTML string).
         height: The CSS height specification.
         name: The unique identifier for this element.
+        tab: The tab path, normalised to a tuple or None.
     """
     def __init__(
             self,
             element: Union[go.Figure, str],
             height: str = '100%',
             name: str = None,
+            tab: Union[str, Tuple[str, str], None] = None,
     ):
         self.element = element
         self.height = height
         self.name = name or str(id(self))
         if name is None:
             logger.info(f'No name passed for {type(self).__name__}. Automatically generated name: {self.name}')
+
+        # Normalise tab to tuple or None
+        if isinstance(tab, str):
+            self.tab = (tab,)
+        elif isinstance(tab, tuple):
+            if len(tab) not in (1, 2):
+                raise ValueError(f"tab tuple must have 1 or 2 elements, got {len(tab)}")
+            self.tab = tab
+        else:
+            self.tab = None
 
 
 class HTMLDashboard:
@@ -72,13 +90,20 @@ class HTMLDashboard:
         self.content: Dict[str, HTMLDashboardElement] = dict()
         self.font_family = font_family
 
-    def add_plotly_figure(self, fig: go.Figure, height: str = '100%', name: str = None):
+    def add_plotly_figure(
+            self,
+            fig: go.Figure,
+            height: str = '100%',
+            name: str = None,
+            tab: Union[str, Tuple[str, str], None] = None,
+    ):
         """Add a Plotly figure to the dashboard.
 
         Args:
             fig: The Plotly figure to add.
             height: CSS height specification for the figure. Defaults to '100%'.
             name: Unique identifier for the figure. If None, auto-generates.
+            tab: Optional tab path (see :class:`HTMLDashboardElement`).
 
         Example:
 
@@ -86,28 +111,30 @@ class HTMLDashboard:
             >>> fig = px.bar(x=["A", "B", "C"], y=[1, 3, 2])
             >>> dashboard.add_plotly_figure(fig, height="400px", name="my_bar_chart")
         """
-        element = HTMLDashboardElement(fig, height, name)
+        element = HTMLDashboardElement(fig, height, name, tab=tab)
         self.content[element.name] = element
 
-    def add_html(self, html_string: str, name: str = None):
+    def add_html(self, html_string: str, name: str = None, tab: Union[str, Tuple[str, str], None] = None):
         """Add custom HTML content to the dashboard.
 
         Args:
             html_string: The HTML content to add.
             name: Unique identifier for the HTML content. If None, auto-generates.
+            tab: Optional tab path (see :class:`HTMLDashboardElement`).
 
         Example:
 
             >>> html = "<div><h2>Custom Section</h2><p>Some content here.</p></div>"
             >>> dashboard.add_html(html, name="custom_section")
         """
-        element = HTMLDashboardElement(html_string, name=name)
+        element = HTMLDashboardElement(html_string, name=name, tab=tab)
         self.content[element.name] = element
 
     def add_folium_map(
             self,
             folium_map: 'folium.Map',
             name: str = None,
+            tab: Union[str, Tuple[str, str], None] = None,
     ):
         """Add a Folium map to the dashboard.
 
@@ -115,6 +142,7 @@ class HTMLDashboard:
             folium_map: The Folium map object to add.
             name: Unique identifier for the map. If None, auto-generates
                 as "folium_map_{index}".
+            tab: Optional tab path (see :class:`HTMLDashboardElement`).
 
         Returns:
             str: The name assigned to the map element.
@@ -132,7 +160,7 @@ class HTMLDashboard:
 
         wrapped_map_html = f'<div>{map_html}</div>'
 
-        self.add_html(wrapped_map_html, name=name)
+        self.add_html(wrapped_map_html, name=name, tab=tab)
 
         return name
 
@@ -140,7 +168,8 @@ class HTMLDashboard:
             self,
             table: 'HTMLTable',
             name: str = None,
-            include_dependencies: bool = True
+            include_dependencies: bool = True,
+            tab: Union[str, Tuple[str, str], None] = None,
     ) -> str:
         """Add an HTML table to the dashboard.
 
@@ -150,6 +179,7 @@ class HTMLDashboard:
                 or uses table_id.
             include_dependencies: Whether to include CSS/JS dependencies in the
                 table HTML. Defaults to True.
+            tab: Optional tab path (see :class:`HTMLDashboardElement`).
 
         Returns:
             str: The name assigned to the table element.
@@ -171,7 +201,7 @@ class HTMLDashboard:
             if name is None:
                 name = f"table_{table.title.lower().replace(' ', '_')}" if table.title else table.table_id
 
-            self.add_html(table_html, name=name)
+            self.add_html(table_html, name=name, tab=tab)
             return name
 
         except Exception as e:
@@ -182,6 +212,7 @@ class HTMLDashboard:
             title: str,
             subtitle: str = None,
             name: str = None,
+            tab: Union[str, Tuple[str, str], None] = None,
             background_color: str = "#f9f9f9",
             title_color: str = "#333",
             subtitle_color: str = "#666",
@@ -204,6 +235,7 @@ class HTMLDashboard:
             title: The main section title.
             subtitle: Optional subtitle text.
             name: Unique identifier for the divider. If None, derives from title.
+            tab: Optional tab path (see :class:`HTMLDashboardElement`).
             background_color: CSS background color. Defaults to "#f9f9f9".
             title_color: CSS color for the title text. Defaults to "#333".
             subtitle_color: CSS color for the subtitle text. Defaults to "#666".
@@ -246,16 +278,245 @@ class HTMLDashboard:
         if name is None:
             name = f"section_{title.lower().replace(' ', '_')}"
 
-        self.add_html(html, name=name)
+        self.add_html(html, name=name, tab=tab)
 
         return name
+
+    # -- internal helpers ------------------------------------------------
+
+    def _has_tabs(self) -> bool:
+        return any(el.tab is not None for el in self.content.values())
+
+    def _resolve_content_order(self, content_order):
+        if content_order is None:
+            return list(self.content.keys())
+        unrecognized = [k for k in content_order if k not in self.content.keys()]
+        if unrecognized:
+            raise KeyError(f'Unrecognized content names: {unrecognized}. Allowed: {self.content.keys()}')
+        return content_order
+
+    def _element_to_html(self, element: HTMLDashboardElement, plotly_js_included: bool) -> str:
+        if isinstance(element.element, go.Figure):
+            return element.element.to_html(
+                include_plotlyjs=not plotly_js_included,
+                full_html=False,
+                default_height=element.height,
+            )
+        elif isinstance(element.element, str):
+            return element.element
+        else:
+            raise TypeError(f'Unexpected element type: {type(element.element)}')
+
+    DEFAULT_TAB = '.'
+
+    def _build_tab_structure(self, content_order):
+        """Return an OrderedDict representing the tab tree.
+
+        Structure::
+
+            {
+                "Market Results": {          # top-level tab
+                    "_elements": [...],      # elements directly in this tab
+                    "Volumes": {             # sub-tab
+                        "_elements": [...],
+                    },
+                },
+                ...
+            }
+        """
+        tabs: OrderedDict = OrderedDict()
+
+        for key in content_order:
+            el = self.content[key]
+            path = el.tab if el.tab is not None else (self.DEFAULT_TAB,)
+
+            top = path[0]
+            if top not in tabs:
+                tabs[top] = OrderedDict(_elements=[])
+
+            if len(path) == 2:
+                sub = path[1]
+                if sub not in tabs[top]:
+                    tabs[top][sub] = OrderedDict(_elements=[])
+                tabs[top][sub]['_elements'].append(key)
+            else:
+                tabs[top]['_elements'].append(key)
+
+        return tabs
+
+    @staticmethod
+    def _tab_css() -> str:
+        return """
+        html, body { height: 100%; margin: 0; }
+        #tabgroup_top { display: flex; flex-direction: column; height: 100vh; }
+        .dashboard-tabs { flex: 0 0 auto; display: flex; flex-wrap: wrap; border-bottom: 2px solid #dee2e6; margin: 0; padding: 0; gap: 2px; }
+        .dashboard-tabs button {
+            padding: 10px 20px; border: 1px solid transparent; border-bottom: none;
+            background: #f8f9fa; cursor: pointer; font-size: 14px; color: #495057;
+            border-radius: 6px 6px 0 0; transition: background 0.15s, color 0.15s;
+        }
+        .dashboard-tabs button:hover { background: #e9ecef; }
+        .dashboard-tabs button.active { background: #fff; color: #212529; border-color: #dee2e6; font-weight: 600; position: relative; }
+        .dashboard-tabs button.active::after { content: ''; position: absolute; bottom: -2px; left: 0; right: 0; height: 2px; background: #fff; }
+        .dashboard-tab-content { display: none; flex: 1 1 0; min-height: 0; overflow: auto; padding: 0; }
+        .dashboard-tab-content.active { display: flex; flex-direction: column; }
+        .dashboard-subtabs { flex: 0 0 auto; display: flex; flex-wrap: wrap; border-bottom: 1px solid #e9ecef; margin: 0; padding: 0; gap: 2px; }
+        .dashboard-subtabs button {
+            padding: 6px 16px; border: 1px solid transparent; border-bottom: none;
+            background: #f8f9fa; cursor: pointer; font-size: 13px; color: #6c757d;
+            border-radius: 4px 4px 0 0; transition: background 0.15s, color 0.15s;
+        }
+        .dashboard-subtabs button:hover { background: #e9ecef; }
+        .dashboard-subtabs button.active { background: #fff; color: #212529; border-color: #e9ecef; font-weight: 600; position: relative; }
+        .dashboard-subtabs button.active::after { content: ''; position: absolute; bottom: -1px; left: 0; right: 0; height: 1px; background: #fff; }
+        .dashboard-subtab-content { display: none; flex: 1 1 0; min-height: 0; overflow: auto; padding: 0; }
+        .dashboard-subtabgroup { display: flex; flex-direction: column; flex: 1 1 0; min-height: 0; }
+        .dashboard-subtab-content.active { display: flex; flex-direction: column; }
+        .dashboard-tab-content .js-plotly-plot,
+        .dashboard-subtab-content .js-plotly-plot { width: 100% !important; flex: 1 1 0; min-height: 0; }
+        .dashboard-tab-content .plotly-graph-div,
+        .dashboard-subtab-content .plotly-graph-div { height: 100% !important; }
+        """
+
+    @staticmethod
+    def _tab_js() -> str:
+        return """
+        function switchTab(groupId, tabId) {
+            var group = document.getElementById(groupId);
+            group.querySelectorAll(':scope > .dashboard-tab-content, :scope > .dashboard-subtab-content').forEach(function(el) {
+                el.classList.remove('active');
+            });
+            var tabs = group.querySelector('.dashboard-tabs') || group.querySelector('.dashboard-subtabs');
+            tabs.querySelectorAll('button').forEach(function(btn) { btn.classList.remove('active'); });
+            document.getElementById(tabId).classList.add('active');
+            document.querySelector('[onclick*=\"\\'' + tabId + '\\'\"]').classList.add('active');
+            // Plotly figures rendered inside hidden tabs have zero dimensions;
+            // resize them once the tab becomes visible.
+            var target = document.getElementById(tabId);
+            var plots = target.querySelectorAll('.plotly-graph-div');
+            plots.forEach(function(p) { if (window.Plotly) Plotly.Plots.resize(p); });
+        }
+        """
+
+    def _render_tabbed(self, content_order) -> str:
+        plotly_js_included = False
+        tab_tree = self._build_tab_structure(content_order)
+        parts = []
+        counter = 0
+
+        def next_id(prefix='tab'):
+            nonlocal counter
+            counter += 1
+            return f'{prefix}_{counter}'
+
+        # Top-level tab bar
+        group_id = 'tabgroup_top'
+        parts.append(f'<div id="{group_id}">')
+        parts.append('<div class="dashboard-tabs">')
+
+        tab_ids = {}
+        first_top = True
+        for tab_label in tab_tree:
+            tid = next_id('tab')
+            tab_ids[tab_label] = tid
+            active = ' active' if first_top else ''
+            parts.append(
+                f"<button class=\"{active.strip()}\" onclick=\"switchTab('{group_id}', '{tid}')\">{tab_label}</button>"
+            )
+            first_top = False
+        parts.append('</div>')
+
+        # Top-level tab contents
+        first_top = True
+        for tab_label, tab_data in tab_tree.items():
+            tid = tab_ids[tab_label]
+            active = ' active' if first_top else ''
+            parts.append(f'<div id="{tid}" class="dashboard-tab-content{active}">')
+
+            # Direct elements in this tab
+            sub_tabs = OrderedDict(
+                (k, v) for k, v in tab_data.items() if k != '_elements'
+            )
+
+            if sub_tabs:
+                # Render sub-tab bar
+                sub_group_id = next_id('subtabgroup')
+                parts.append(f'<div id="{sub_group_id}" class="dashboard-subtabgroup">')
+                parts.append('<div class="dashboard-subtabs">')
+
+                # If there are direct elements, they go in a "General" sub-tab
+                direct_elements = tab_data['_elements']
+                sub_tab_ids = {}
+                first_sub = True
+
+                if direct_elements:
+                    stid = next_id('subtab')
+                    sub_tab_ids['_direct'] = stid
+                    active_s = ' active' if first_sub else ''
+                    parts.append(
+                        f"<button class=\"{active_s.strip()}\" onclick=\"switchTab('{sub_group_id}', '{stid}')\">{self.DEFAULT_TAB}</button>"
+                    )
+                    first_sub = False
+
+                for sub_label in sub_tabs:
+                    stid = next_id('subtab')
+                    sub_tab_ids[sub_label] = stid
+                    active_s = ' active' if first_sub else ''
+                    parts.append(
+                        f"<button class=\"{active_s.strip()}\" onclick=\"switchTab('{sub_group_id}', '{stid}')\">{sub_label}</button>"
+                    )
+                    first_sub = False
+
+                parts.append('</div>')
+
+                # Sub-tab contents
+                first_sub = True
+                if direct_elements:
+                    stid = sub_tab_ids['_direct']
+                    active_s = ' active' if first_sub else ''
+                    parts.append(f'<div id="{stid}" class="dashboard-subtab-content{active_s}">')
+                    for key in direct_elements:
+                        el = self.content[key]
+                        parts.append(self._element_to_html(el, plotly_js_included))
+                        if isinstance(el.element, go.Figure):
+                            plotly_js_included = True
+                    parts.append('</div>')
+                    first_sub = False
+
+                for sub_label, sub_data in sub_tabs.items():
+                    stid = sub_tab_ids[sub_label]
+                    active_s = ' active' if first_sub else ''
+                    parts.append(f'<div id="{stid}" class="dashboard-subtab-content{active_s}">')
+                    for key in sub_data['_elements']:
+                        el = self.content[key]
+                        parts.append(self._element_to_html(el, plotly_js_included))
+                        if isinstance(el.element, go.Figure):
+                            plotly_js_included = True
+                    parts.append('</div>')
+                    first_sub = False
+
+                parts.append('</div>')  # close sub_group_id
+            else:
+                # No sub-tabs — just render direct elements
+                for key in tab_data['_elements']:
+                    el = self.content[key]
+                    parts.append(self._element_to_html(el, plotly_js_included))
+                    if isinstance(el.element, go.Figure):
+                        plotly_js_included = True
+
+            parts.append('</div>')  # close tab content
+            first_top = False
+
+        parts.append('</div>')  # close tabgroup_top
+        return '\n'.join(parts)
+
+    # -- public API ----------------------------------------------------
 
     def save(self, save_to_path, content_order=None):
         """Save the dashboard as an HTML file.
 
-        Generates a complete HTML document containing all dashboard elements.
-        Automatically handles Plotly.js inclusion (only includes once for efficiency)
-        and creates output directories as needed.
+        If any element has a ``tab`` set, the dashboard is rendered with a tabbed
+        layout. Otherwise it falls back to the classic scrollable layout.
 
         Args:
             save_to_path: File path where the HTML dashboard will be saved.
@@ -274,44 +535,35 @@ class HTMLDashboard:
             >>> dashboard.save("ordered_dashboard.html",
             ...               content_order=["intro_section", "chart1", "table1"])
         """
-        if not os.path.exists(os.path.dirname(save_to_path)):
-            os.makedirs(os.path.dirname(save_to_path))
+        dir_name = os.path.dirname(save_to_path)
+        if dir_name and not os.path.exists(dir_name):
+            os.makedirs(dir_name)
 
-        if content_order is None:
-            content_order = list(self.content.keys())
-        else:
-            unrecognized = [k for k in content_order if k not in self.content.keys()]
-            if unrecognized:
-                raise KeyError(f'Unrecognized content names: {unrecognized}. Allowed: {self.content.keys()}')
+        content_order = self._resolve_content_order(content_order)
+        use_tabs = self._has_tabs()
 
-        content = []
-        plotly_js_included = False
-        for key in content_order:
-            v = self.content[key]
-            if isinstance(v.element, go.Figure):
-                html_text = v.element.to_html(
-                    include_plotlyjs=True if not plotly_js_included else False,
-                    full_html=False,
-                    default_height=v.height
-                )
-                content.append(html_text)
-                plotly_js_included = True
-            elif isinstance(v.element, str):
-                content.append(v.element)
+        with open(save_to_path, 'w', encoding='utf-8') as f:
+            f.write("<html><head>\n")
+            f.write("<meta charset='UTF-8'>\n")
+            f.write(f"<title>{self.name}</title>\n")
+            f.write(f"<style>\n  body, * {{ font-family: {self.font_family}; }}\n")
+            if use_tabs:
+                f.write(self._tab_css())
+            f.write("</style>\n")
+            f.write("</head><body>\n")
+
+            if use_tabs:
+                f.write(self._render_tabbed(content_order))
+                f.write(f"\n<script>\n{self._tab_js()}\n</script>\n")
             else:
-                TypeError(f'Unexpected element type: {type(v.element)}')
+                plotly_js_included = False
+                for key in content_order:
+                    el = self.content[key]
+                    f.write(self._element_to_html(el, plotly_js_included) + "\n")
+                    if isinstance(el.element, go.Figure):
+                        plotly_js_included = True
 
-        with open(save_to_path, 'w', encoding='utf-8') as dashboard:
-            dashboard.write("<html><head>\n")
-            dashboard.write("<meta charset='UTF-8'>\n")
-            dashboard.write(f"<title>{self.name}</title>\n")
-            dashboard.write(f"<style>\n  body, * {{ font-family: {self.font_family}; }}\n</style>\n")
-            dashboard.write("</head><body>\n")
-
-            for item in content:
-                dashboard.write(item + "\n")
-
-            dashboard.write("</body></html>\n")
+            f.write("</body></html>\n")
 
     def show(self, width: str = "100%", height: str = "600"):
         """Display the dashboard inline in a Jupyter notebook.
@@ -351,13 +603,12 @@ if __name__ == '__main__':
     # Load sample data
     data = px.data.iris()
 
-    # Create dashboard
+    # ── Classic scrollable dashboard (no tabs) ──────────────────────────
     dashboard = HTMLDashboard(
-        name='MESQUAL Visualization Dashboard',
+        name='MESQUAL Visualization Dashboard (scroll)',
         font_family="'Segoe UI', Tahoma, Geneva, Verdana, sans-serif"
     )
 
-    # Add main header
     dashboard.add_section_divider(
         title='MESQUAL Dashboard Example',
         subtitle='Demonstrating multiple visualization types',
@@ -367,62 +618,56 @@ if __name__ == '__main__':
         border_radius="8px"
     )
 
-    # Add plotly figures with different types
-    scatter_fig = px.scatter(
-        data,
-        x="sepal_width",
-        y="sepal_length",
-        color="species",
-        title="Sepal Dimensions by Species"
-    )
-    dashboard.add_plotly_figure(
-        scatter_fig,
-        height="450px",
-        name="sepal_scatter"
+    scatter_fig = px.scatter(data, x="sepal_width", y="sepal_length", color="species",
+                             title="Sepal Dimensions by Species")
+    dashboard.add_plotly_figure(scatter_fig, height="450px", name="sepal_scatter")
+
+    box_fig = px.box(data, x="species", y="petal_length", title="Petal Length Distribution")
+    dashboard.add_plotly_figure(box_fig, height="400px", name="petal_boxplot")
+
+    dashboard.save('_tmp/figure_dashboard_scroll.html')
+    print("Scroll dashboard saved to '_tmp/figure_dashboard_scroll.html'")
+
+    # ── Tabbed dashboard ────────────────────────────────────────────────
+    tabbed = HTMLDashboard(
+        name='MESQUAL Visualization Dashboard (tabs)',
+        font_family="'Segoe UI', Tahoma, Geneva, Verdana, sans-serif"
     )
 
-    # Box plot example
-    box_fig = px.box(
-        data,
-        x="species",
-        y="petal_length",
-        title="Petal Length Distribution"
-    )
-    dashboard.add_plotly_figure(
-        box_fig,
-        height="400px",
-        name="petal_boxplot"
+    # Elements without tab → go to default "." tab
+    tabbed.add_section_divider(
+        title='MESQUAL Dashboard Example',
+        subtitle='Demonstrating the tabbed layout',
+        background_color="#2c3e50",
+        title_color="white",
+        subtitle_color="#ecf0f1",
+        border_radius="8px"
     )
 
-    # Custom plotly figure with annotations
+    # Top-level tab "Charts"
+    tabbed.add_plotly_figure(scatter_fig, height="450px", name="sepal_scatter",
+                             tab="Charts")
+    tabbed.add_plotly_figure(box_fig, height="400px", name="petal_boxplot",
+                             tab="Charts")
+
+    # Nested sub-tab ("Charts", "Custom")
     custom_fig = go.Figure()
     custom_fig.add_scatter(
-        x=data["sepal_width"],
-        y=data["petal_length"],
-        mode='markers',
+        x=data["sepal_width"], y=data["petal_length"], mode='markers',
         marker=dict(size=8, color='lightblue', line=dict(width=1, color='navy')),
-        name='All Species'
+        name='All Species',
     )
-    custom_fig.update_layout(
-        title="Custom Scatter Plot with Styling",
-        xaxis_title="Sepal Width (cm)",
-        yaxis_title="Petal Length (cm)"
-    )
-    dashboard.add_plotly_figure(custom_fig, name="custom_scatter")
+    custom_fig.update_layout(title="Custom Scatter Plot with Styling",
+                             xaxis_title="Sepal Width (cm)",
+                             yaxis_title="Petal Length (cm)")
+    tabbed.add_plotly_figure(custom_fig, name="custom_scatter",
+                             tab=("Charts", "Custom"))
 
-    # Add data table section
-    dashboard.add_section_divider(
-        'Data Table Integration',
-        'Interactive table with the underlying data'
-    )
-
-    # Create and add table
-    sample_data = data.head(10)  # First 10 rows for demo
+    # Another top-level tab "Data"
+    sample_data = data.head(10)
     table = HTMLTable(sample_data, title="Iris Dataset Sample")
-    dashboard.add_table(table, name="iris_sample_table")
+    tabbed.add_table(table, name="iris_sample_table", tab="Data")
 
-    # Add custom HTML content
-    dashboard.add_section_divider('Custom HTML Content')
     custom_html = """
     <div style="background-color: #f8f9fa; padding: 20px; border-left: 4px solid #007bff;">
         <h3 style="color: #007bff; margin-top: 0;">Analysis Summary</h3>
@@ -432,27 +677,14 @@ if __name__ == '__main__':
             <li><strong>Species:</strong> Setosa, Versicolor, Virginica</li>
             <li><strong>Variables:</strong> Sepal/Petal length and width</li>
         </ul>
-        <p><em>This dashboard demonstrates the integration of multiple visualization types
-        using the MESQUAL HTMLDashboard class.</em></p>
     </div>
     """
-    dashboard.add_html(custom_html, name="analysis_summary")
+    tabbed.add_html(custom_html, name="analysis_summary", tab="Data")
 
-    # Save dashboard with custom content order
-    content_order = [
-        "section_mesqual_dashboard_example",
-        "sepal_scatter",
-        "petal_boxplot",
-        "custom_scatter",
-        "section_data_table_integration",
-        "iris_sample_table",
-        "section_custom_html_content",
-        "analysis_summary"
-    ]
-
-    dashboard.save('_tmp/figure_dashboard.html', content_order=content_order)
-    print("Dashboard saved to '_tmp/figure_dashboard.html'")
-    print(f"Dashboard contains {len(dashboard.content)} elements:")
-    for name, element in dashboard.content.items():
+    tabbed.save('_tmp/figure_dashboard_tabs.html')
+    print("Tabbed dashboard saved to '_tmp/figure_dashboard_tabs.html'")
+    print(f"Dashboard contains {len(tabbed.content)} elements:")
+    for name, element in tabbed.content.items():
         element_type = "Plotly Figure" if isinstance(element.element, go.Figure) else "HTML Content"
-        print(f"  - {name}: {element_type}")
+        tab_info = f" (tab: {element.tab})" if element.tab else ""
+        print(f"  - {name}: {element_type}{tab_info}")


### PR DESCRIPTION
## Summary
- **Granularity converter**: Simplified to use `pandas.resample` directly instead of per-day groupby + granularity analysis. New `convert()` method accepts both Series and DataFrames (including mixed-granularity columns), with target frequency as string or Timedelta. Existing methods delegate to `convert()` for backward compatibility. Handles empty DataFrames and NaT from single-row days gracefully.
- **Trade balance**: Added `total` (export + import) variable to `RegionalTradeBalanceCalculator`.
- **StudyManager**: Replaced `export_folder` with `study_folder` (`Path`-based), removed folder creation side-effects.
- **Aggregations**: Added `Ratio` as a value comparison type.
- **DatasetConfigManager**: `get_effective_config` now resolves class configs through the MRO, so configs set on a parent dataset class are automatically inherited by subclasses without needing to register them on each subclass individually.
- **PickleDatabase**: Fixed non-deterministic config hashing — uses stable MD5 hash instead of Python's built-in `hash()`, uses `vars()` instead of `dir()` for config attribute discovery, and normalizes lists/sets/dicts before hashing for order-independence.
- **DatasetConfig**: `merge()` and `__repr__()` now use `vars()` instead of `dir()` to prevent leaking bound methods as instance attributes.

## Test plan
- [x] Verify granularity conversion round-trips (hourly ↔ 15min) for both intensive and extensive quantities
- [x] Verify mixed-granularity DataFrame conversion
- [x] Verify trade balance total equals export + import
- [ ] Verify StudyManager accepts str and Path for study_folder
- [ ] Verify class config set on a parent class is resolved for subclass instances
- [ ] Verify config hash is deterministic across Python sessions
- [ ] Verify config hash is stable for configs containing lists/sets